### PR TITLE
Add initial Claude Code settings and setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Editor directories and files
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.idea
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.temp
+.cache/
+
+# Personal/sensitive data
+*.local

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
 # claude-code-settings
 Claude Codeで利用するグローバル設定をまとめたリポジトリ。
+
+## ディレクトリ構造
+
+```
+claude-code-settings/
+├── .gitignore          # Git管理対象外ファイルの設定
+├── README.md           # このファイル
+├── setup.sh            # セットアップスクリプト（シンボリックリンク作成）
+└── settings.json       # Claude Codeのグローバル設定ファイル
+```
+
+## ファイル説明
+
+- **settings.json**: Claude Codeのグローバル設定を定義するファイル
+- **setup.sh**: 設定ファイルのシンボリックリンクを自動作成するスクリプト
+- **.gitignore**: OS固有のファイルやエディタの一時ファイルなどを除外
+- **README.md**: リポジトリの説明とディレクトリ構造
+
+## セットアップ
+
+1. このリポジトリをクローン
+   ```bash
+   git clone <repository-url>
+   cd claude-code-settings
+   ```
+
+2. セットアップスクリプトを実行
+   ```bash
+   ./setup.sh
+   ```
+
+   スクリプトは以下の処理を自動で行います：
+   - `~/.claude`ディレクトリが存在しない場合は作成
+   - 既存の`settings.json`がある場合はバックアップを作成
+   - このリポジトリの`settings.json`へのシンボリックリンクを作成
+
+3. 設定の確認
+   ```bash
+   ls -la ~/.claude/settings.json
+   ```
+
+## 設定の変更
+
+このリポジトリの`settings.json`を編集すると、Claude Codeの設定に即座に反映されます。
+
+```bash
+# 設定ファイルを編集
+vim settings.json  # または好きなエディタで編集
+
+# 変更をコミット
+git add settings.json
+git commit -m "Update Claude Code settings"
+git push
+```

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "defaultMode": "dontAsk",
+    "permissions": {
+        "allow": [
+            "Bash",
+            "Read",
+            "Edit",
+            "Write",
+            "Grep",
+            "Glob"
+        ],
+        "ask": [
+            "Bash(rm -rf *)",
+            "Bash(sudo *)",
+            "Bash(chmod -R 777 *)",
+            "Bash(curl * | sh)",
+            "Bash(curl * | bash)",
+            "Bash(wget * | sh)",
+            "Bash(wget * | bash)"
+        ],
+        "deny": [
+            "Bash(git push * main)",
+            "Bash(git push * master)",
+            "Bash(git push -f *)",
+            "Bash(git push --force *)",
+            "Bash(dd *)",
+            "Bash(mkfs*)",
+            "Bash(fdisk *)",
+            "Bash(parted *)"
+        ]
+    },
+    "model": "sonnet",
+    "env": {
+        "CLAUDE_CODE_ENABLE_TELEMETRY": "1"
+    },
+    "attribution": {
+        "commit": "Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>",
+        "pr": "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+    },
+    "outputStyle": "concise",
+    "language": "ja"
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+# 色の定義
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# 設定ファイルのパス
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_FILE="${SCRIPT_DIR}/settings.json"
+TARGET_DIR="${HOME}/.claude"
+TARGET_FILE="${TARGET_DIR}/settings.json"
+
+echo "Claude Code設定ファイルのセットアップを開始します..."
+echo ""
+
+# .claudeディレクトリが存在しない場合は作成
+if [ ! -d "${TARGET_DIR}" ]; then
+    echo -e "${YELLOW}~/.claudeディレクトリが存在しないため、作成します${NC}"
+    mkdir -p "${TARGET_DIR}"
+    echo -e "${GREEN}✓ ~/.claudeディレクトリを作成しました${NC}"
+fi
+
+# 既存のsettings.jsonファイルが存在する場合の処理
+if [ -e "${TARGET_FILE}" ]; then
+    # シンボリックリンクの場合
+    if [ -L "${TARGET_FILE}" ]; then
+        LINK_TARGET=$(readlink "${TARGET_FILE}")
+        if [ "${LINK_TARGET}" = "${SOURCE_FILE}" ]; then
+            echo -e "${GREEN}✓ すでに正しいシンボリックリンクが設定されています${NC}"
+            exit 0
+        else
+            echo -e "${YELLOW}既存のシンボリックリンクを削除します: ${LINK_TARGET}${NC}"
+            rm "${TARGET_FILE}"
+        fi
+    # 通常のファイルの場合
+    else
+        BACKUP_FILE="${TARGET_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
+        echo -e "${YELLOW}既存のsettings.jsonをバックアップします: ${BACKUP_FILE}${NC}"
+        mv "${TARGET_FILE}" "${BACKUP_FILE}"
+        echo -e "${GREEN}✓ バックアップを作成しました${NC}"
+    fi
+fi
+
+# シンボリックリンクを作成
+echo "シンボリックリンクを作成しています..."
+ln -s "${SOURCE_FILE}" "${TARGET_FILE}"
+
+# 確認
+if [ -L "${TARGET_FILE}" ] && [ "$(readlink "${TARGET_FILE}")" = "${SOURCE_FILE}" ]; then
+    echo ""
+    echo -e "${GREEN}✓ セットアップが完了しました！${NC}"
+    echo ""
+    echo "設定内容:"
+    echo "  元ファイル: ${SOURCE_FILE}"
+    echo "  リンク先:   ${TARGET_FILE}"
+    echo ""
+    echo "設定を変更する場合は、このリポジトリのsettings.jsonを編集してください。"
+else
+    echo ""
+    echo -e "${RED}✗ シンボリックリンクの作成に失敗しました${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Claude Codeのグローバル設定ファイル（settings.json）を追加
- シンボリックリンク作成の自動化スクリプト（setup.sh）を追加
- .gitignoreファイルを追加
- README.mdにディレクトリ構造、ファイル説明、セットアップ手順を追加

## 主な設定内容
- **permissions**: 基本的にすべて許可、破壊的コマンドのみ確認/拒否
- **model**: デフォルトモデルをSonnetに設定
- **attribution**: コミットとPRに自動署名を追加
- **language**: 日本語設定

## Test plan
- [x] setup.shスクリプトが正常に動作することを確認
- [x] シンボリックリンクが正しく作成されることを確認
- [x] 既存ファイルのバックアップが正しく作成されることを確認
- [x] settings.jsonの設定が有効であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)