### PR TITLE
CLAUDE.mdのグローバル展開を廃止し、プロジェクトルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,7 @@
 # CLAUDE.md
+
+## Rules
+
+- Never edit files under `~/.claude/` directly. All changes must be made to files in this repository.
+- Always refer to the official documentation ( https://code.claude.com/docs/en/settings ) when changing settings.
+- Write all prompts (CLAUDE.md, rules, agents, skills, etc.) in English for token efficiency.

--- a/clean.sh
+++ b/clean.sh
@@ -49,9 +49,6 @@ remove_symlink() {
 echo "シンボリックリンクを削除しています..."
 echo ""
 
-# CLAUDE.md
-remove_symlink "${SCRIPT_DIR}/CLAUDE.md" "${TARGET_DIR}/CLAUDE.md" "CLAUDE.md"
-
 # settings.json
 remove_symlink "${SCRIPT_DIR}/settings.json" "${TARGET_DIR}/settings.json" "settings.json"
 

--- a/setup.sh
+++ b/setup.sh
@@ -73,9 +73,6 @@ create_symlink() {
 echo "シンボリックリンクを作成しています..."
 echo ""
 
-# CLAUDE.md (グローバルプロジェクトメモリ)
-create_symlink "${SCRIPT_DIR}/CLAUDE.md" "${TARGET_DIR}/CLAUDE.md" "CLAUDE.md"
-
 # settings.json
 create_symlink "${SCRIPT_DIR}/settings.json" "${TARGET_DIR}/settings.json" "settings.json"
 
@@ -108,7 +105,6 @@ echo "  リポジトリ: ${SCRIPT_DIR}"
 echo "  リンク先:   ${TARGET_DIR}"
 echo ""
 echo "作成されたシンボリックリンク:"
-echo "  - CLAUDE.md"
 echo "  - settings.json"
 echo "  - agents/"
 echo "  - skills/"


### PR DESCRIPTION
## 変更内容

- `setup.sh` / `clean.sh` から `CLAUDE.md` のシンボリックリンク処理を削除
  - `CLAUDE.md` はこのリポジトリ固有のプロジェクト指示であり、グローバル設定として展開する意図がないため
- `CLAUDE.md` にプロジェクトルールを英語で記述
  - `~/.claude/` を直接編集しない
  - 設定変更時は公式ドキュメントを参照
  - プロンプトは英語で記述（トークン効率化）